### PR TITLE
Make `type_parameters` strict, pass tuples to `type_parameters`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TypeParameterAccessors"
 uuid = "7e5a90cf-f82e-492e-a09b-e3e26432c138"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
-version = "0.1.0"
+version = "0.2.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ using Test: @test
 using TypeParameterAccessors
 ````
 
-Getting type parameters
+Get type parameters:
 
 ````julia
 @test type_parameters(Array{Float64}, 1) == Float64
@@ -44,10 +44,10 @@ Getting type parameters
 @test type_parameters(Matrix{Float64}) == (Float64, 2)
 @test type_parameters(Array{Float64}, eltype) == Float64
 @test type_parameters(Matrix{Float64}, ndims) == 2
-@test type_parameters.(Matrix{Float64}, (eltype, ndims)) == (Float64, 2)
+@test type_parameters(Matrix{Float64}, (eltype, ndims)) == (Float64, 2)
 ````
 
-Setting type parameters
+Set type parameters:
 
 ````julia
 @test set_type_parameters(Array, 1, Float32) == Array{Float32}
@@ -57,7 +57,7 @@ Setting type parameters
 @test set_type_parameters(Array, (eltype, ndims), (Float32, 2)) == Matrix{Float32}
 ````
 
-Specifying type parameters
+Specify type parameters:
 
 ````julia
 @test specify_type_parameters(Array{Float64}, (eltype, ndims), (Float32, 2)) ==
@@ -66,7 +66,7 @@ Specifying type parameters
 @test specify_type_parameters(Array{Float64}, eltype, Float32) == Array{Float64}
 ````
 
-Unspecifying type parameters
+Unspecify type parameters:
 
 ````julia
 @test unspecify_type_parameters(Matrix{Float32}) == Array
@@ -81,9 +81,10 @@ Getting default type parameters
 @test default_type_parameters(Array) == (Float64, 1)
 @test default_type_parameters(Array, eltype) == Float64
 @test default_type_parameters(Array, 2) == 1
+@test default_type_parameters(Array, (eltype, ndims)) == (Float64, 1)
 ````
 
-Setting default type parameters
+Set default type parameters:
 
 ````julia
 @test set_default_type_parameters(Array) == Vector{Float64}
@@ -91,7 +92,7 @@ Setting default type parameters
 @test set_default_type_parameters(Array, 2) == Vector
 ````
 
-Specifying default type parameters
+Specify default type parameters:
 
 ````julia
 @test specify_default_type_parameters(Matrix, (eltype, ndims)) == Matrix{Float64}
@@ -99,7 +100,7 @@ Specifying default type parameters
 @test specify_default_type_parameters(Array{Float32}, (eltype, ndims)) == Vector{Float32}
 ````
 
-Other functionality
+Other functionality:
 
 - `parenttype`
 - `unwrap_array_type`

--- a/docs/src/lib/index.md
+++ b/docs/src/lib/index.md
@@ -25,6 +25,7 @@ Pages = ["index.md"]
 position
 Position
 type_parameters
+get_type_parameters
 default_type_parameters
 nparameters
 is_parameter_specified

--- a/examples/README.jl
+++ b/examples/README.jl
@@ -40,28 +40,28 @@ julia> Pkg.add("TypeParameterAccessors")
 using Test: @test
 using TypeParameterAccessors
 
-# Getting type parameters
+# Get type parameters:
 @test type_parameters(Array{Float64}, 1) == Float64
 @test type_parameters(Matrix{Float64}, 2) == 2
 @test type_parameters(Matrix{Float64}) == (Float64, 2)
 @test type_parameters(Array{Float64}, eltype) == Float64
 @test type_parameters(Matrix{Float64}, ndims) == 2
-@test type_parameters.(Matrix{Float64}, (eltype, ndims)) == (Float64, 2)
+@test type_parameters(Matrix{Float64}, (eltype, ndims)) == (Float64, 2)
 
-# Setting type parameters
+# Set type parameters:
 @test set_type_parameters(Array, 1, Float32) == Array{Float32}
 @test set_type_parameters(Array, (1,), (Float32,)) == Array{Float32}
 @test set_type_parameters(Array, (1, 2), (Float32, 2)) == Matrix{Float32}
 @test set_type_parameters(Array, (eltype,), (Float32,)) == Array{Float32}
 @test set_type_parameters(Array, (eltype, ndims), (Float32, 2)) == Matrix{Float32}
 
-# Specifying type parameters
+# Specify type parameters:
 @test specify_type_parameters(Array{Float64}, (eltype, ndims), (Float32, 2)) ==
   Matrix{Float64}
 @test specify_type_parameters(Array{Float64}, ndims, 2) == Matrix{Float64}
 @test specify_type_parameters(Array{Float64}, eltype, Float32) == Array{Float64}
 
-# Unspecifying type parameters
+# Unspecify type parameters:
 @test unspecify_type_parameters(Matrix{Float32}) == Array
 @test unspecify_type_parameters(Matrix{Float32}, 1) == Matrix
 @test unspecify_type_parameters(Matrix{Float32}, (eltype,)) == Matrix
@@ -71,18 +71,19 @@ using TypeParameterAccessors
 @test default_type_parameters(Array) == (Float64, 1)
 @test default_type_parameters(Array, eltype) == Float64
 @test default_type_parameters(Array, 2) == 1
+@test default_type_parameters(Array, (eltype, ndims)) == (Float64, 1)
 
-# Setting default type parameters
+# Set default type parameters:
 @test set_default_type_parameters(Array) == Vector{Float64}
 @test set_default_type_parameters(Array, (eltype,)) == Array{Float64}
 @test set_default_type_parameters(Array, 2) == Vector
 
-# Specifying default type parameters
+# Specify default type parameters:
 @test specify_default_type_parameters(Matrix, (eltype, ndims)) == Matrix{Float64}
 @test specify_default_type_parameters(Matrix, eltype) == Matrix{Float64}
 @test specify_default_type_parameters(Array{Float32}, (eltype, ndims)) == Vector{Float32}
 
-# Other functionality
+# Other functionality:
 #
 # - `parenttype`
 # - `unwrap_array_type`

--- a/src/TypeParameterAccessors.jl
+++ b/src/TypeParameterAccessors.jl
@@ -1,7 +1,7 @@
 module TypeParameterAccessors
 
 # Exports
-export type_parameters
+export type_parameters, get_type_parameters
 export nparameters, is_parameter_specified
 export default_type_parameters
 export set_type_parameters, set_default_type_parameters

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -6,6 +6,7 @@ StridedViews = "4db3bf67-4bd7-4b4e-b153-31dc3fb37143"
 Suppressor = "fd094767-a336-5f1f-9728-57cf17d0bbfb"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TestExtras = "5ed8adda-3752-4e41-b88a-e8b09835ee3a"
+TypeParameterAccessors = "7e5a90cf-f82e-492e-a09b-e3e26432c138"
 
 [compat]
 Aqua = "0.8.9"

--- a/test/test_basics.jl
+++ b/test/test_basics.jl
@@ -1,4 +1,4 @@
-using Test: @test_throws, @testset
+using Test: @test, @test_throws, @test_broken, @testset
 using TestExtras: @constinferred
 using TypeParameterAccessors:
   set_type_parameters, specify_type_parameters, type_parameters, unspecify_type_parameters
@@ -14,7 +14,12 @@ using TypeParameterAccessors:
   # @test_throws ErrorException type_parameter(Array, 1)
   @test @constinferred(type_parameters($(Array{Float64}), eltype)) == Float64
   @test @constinferred(type_parameters($(Matrix{Float64}), ndims)) == 2
-  # @test_throws ErrorException type_parameter(Array{Float64}, ndims) == 2
+  @test @constinferred(type_parameters($(Matrix{Float64}), (ndims, eltype))) == (2, Float64)
+  # TODO: Not inferrable without interpolating positions:
+  # https://github.com/ITensor/TypeParameterAccessors.jl/issues/21.
+  @test @constinferred(type_parameters($(Matrix{Float64}), $((2, eltype)))) == (2, Float64)
+  @test @constinferred(type_parameters($(Matrix{Float64}), (ndims, eltype))) == (2, Float64)
+  # @test_throws ErrorException type_parameters(Array{Float64}, ndims) == 2
   @test @constinferred(broadcast($type_parameters, $(Matrix{Float64}), $((2, eltype)))) ==
     (2, Float64)
 end

--- a/test/test_defaults.jl
+++ b/test/test_defaults.jl
@@ -12,8 +12,7 @@ using TestExtras: @constinferred
     @test @constinferred(default_type_parameters($Array, 1)) == Float64
     @test @constinferred(default_type_parameters($Array, 2)) == 1
     @test @constinferred(default_type_parameters($Array)) == (Float64, 1)
-    @test @constinferred(default_type_parameters($Array, $((2, 1)))) ==
-      (1, Float64)
+    @test @constinferred(default_type_parameters($Array, $((2, 1)))) == (1, Float64)
     @test @constinferred(broadcast($default_type_parameters, $Array, (ndims, eltype))) ==
       (1, Float64)
     @test @constinferred(broadcast($default_type_parameters, $Array, $((2, 1)))) ==

--- a/test/test_defaults.jl
+++ b/test/test_defaults.jl
@@ -12,6 +12,10 @@ using TestExtras: @constinferred
     @test @constinferred(default_type_parameters($Array, 1)) == Float64
     @test @constinferred(default_type_parameters($Array, 2)) == 1
     @test @constinferred(default_type_parameters($Array)) == (Float64, 1)
+    @test @constinferred(default_type_parameters($Array, $((2, 1)))) ==
+      (1, Float64)
+    @test @constinferred(broadcast($default_type_parameters, $Array, (ndims, eltype))) ==
+      (1, Float64)
     @test @constinferred(broadcast($default_type_parameters, $Array, $((2, 1)))) ==
       (1, Float64)
     @test @constinferred(broadcast($default_type_parameters, $Array, (ndims, eltype))) ==


### PR DESCRIPTION
Closes #20, closes #22, closes #19.

This includes an initial implementation of #17, `type_parameters` is now written in terms of an unchecked `get_type_parameters` and throws an error if the parameter is `TypeVar`. This doesn't implement the feature that you can customize the return value to something besides `TypeVar`, and also doesn't add the feature that you can set a type parameter to `TypeVar` in `set_type_parameters`.