### PR TITLE
Add FillArrays package extension

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TypeParameterAccessors"
 uuid = "7e5a90cf-f82e-492e-a09b-e3e26432c138"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -9,8 +9,10 @@ SimpleTraits = "699a6c99-e7fa-54fc-8d76-47d257e15c1d"
 
 [weakdeps]
 StridedViews = "4db3bf67-4bd7-4b4e-b153-31dc3fb37143"
+FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"
 
 [compat]
+FillArrays = "1.13"
 LinearAlgebra = "1.10"
 SimpleTraits = "0.9.4"
 StridedViews = "0.3.2"
@@ -18,3 +20,4 @@ julia = "1.10"
 
 [extensions]
 TypeParameterAccessorsStridedViewsExt = "StridedViews"
+TypeParameterAccessorsFillArraysExt = "FillArrays"

--- a/ext/TypeParameterAccessorsFillArraysExt.jl
+++ b/ext/TypeParameterAccessorsFillArraysExt.jl
@@ -1,0 +1,13 @@
+module TypeParameterAccessorsFillArraysExt
+
+using TypeParameterAccessors: TypeParameterAccessors, Position
+using FillArrays: Fill, Zeros, Ones
+
+for T in (:Fill, :Zeros, :Ones)
+  @eval TypeParameterAccessors.position(::Type{<:$T}, ::typeof(eltype)) = Position(1)
+  @eval TypeParameterAccessors.position(::Type{<:$T}, ::typeof(ndims)) = Position(2)
+  @eval TypeParameterAccessors.position(::Type{<:$T}, ::typeof(axes)) = Position(3)
+  @eval TypeParameterAccessors.default_type_parameters(::Type{<:$T}) = (Float64, 0, Tuple{})
+end
+
+end

--- a/ext/TypeParameterAccessorsFillArraysExt.jl
+++ b/ext/TypeParameterAccessorsFillArraysExt.jl
@@ -8,7 +8,8 @@ for T in (:Fill, :Zeros, :Ones)
     TypeParameterAccessors.position(::Type{<:$T}, ::typeof(eltype)) = Position(1)
     TypeParameterAccessors.position(::Type{<:$T}, ::typeof(ndims)) = Position(2)
     TypeParameterAccessors.position(::Type{<:$T}, ::typeof(axes)) = Position(3)
-    TypeParameterAccessors.default_type_parameters(::Type{<:$T}) = (Float64, 0, Tuple{})
+    TypeParameterAccessors.default_type_parameters(::Type{<:$T}) =
+      (Float64, 1, Tuple{Base.OneTo{Int}})
   end
 end
 

--- a/ext/TypeParameterAccessorsFillArraysExt.jl
+++ b/ext/TypeParameterAccessorsFillArraysExt.jl
@@ -4,10 +4,12 @@ using TypeParameterAccessors: TypeParameterAccessors, Position
 using FillArrays: Fill, Zeros, Ones
 
 for T in (:Fill, :Zeros, :Ones)
-  @eval TypeParameterAccessors.position(::Type{<:$T}, ::typeof(eltype)) = Position(1)
-  @eval TypeParameterAccessors.position(::Type{<:$T}, ::typeof(ndims)) = Position(2)
-  @eval TypeParameterAccessors.position(::Type{<:$T}, ::typeof(axes)) = Position(3)
-  @eval TypeParameterAccessors.default_type_parameters(::Type{<:$T}) = (Float64, 0, Tuple{})
+  @eval begin
+    TypeParameterAccessors.position(::Type{<:$T}, ::typeof(eltype)) = Position(1)
+    TypeParameterAccessors.position(::Type{<:$T}, ::typeof(ndims)) = Position(2)
+    TypeParameterAccessors.position(::Type{<:$T}, ::typeof(axes)) = Position(3)
+    TypeParameterAccessors.default_type_parameters(::Type{<:$T}) = (Float64, 0, Tuple{})
+  end
 end
 
 end

--- a/ext/TypeParameterAccessorsStridedViewsExt.jl
+++ b/ext/TypeParameterAccessorsStridedViewsExt.jl
@@ -3,9 +3,9 @@ module TypeParameterAccessorsStridedViewsExt
 using StridedViews: StridedView
 using TypeParameterAccessors: TypeParameterAccessors, Position, parenttype
 
-function TypeParameterAccessors.position(
-  ::Type{T}, ::typeof(parenttype)
-) where {T<:StridedView}
+TypeParameterAccessors.position(::Type{<:StridedView}, ::typeof(eltype)) = Position(1)
+TypeParameterAccessors.position(::Type{<:StridedView}, ::typeof(ndims)) = Position(2)
+function TypeParameterAccessors.position(::Type{<:StridedView}, ::typeof(parenttype))
   return Position(3)
 end
 

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -12,6 +12,7 @@ TypeParameterAccessors = "7e5a90cf-f82e-492e-a09b-e3e26432c138"
 [compat]
 Aqua = "0.8.9"
 FillArrays = "1.13"
+StridedViews = "0.3"
 SafeTestsets = "0.1"
 Suppressor = "0.2"
 Test = "1.10"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 StridedViews = "4db3bf67-4bd7-4b4e-b153-31dc3fb37143"
@@ -10,6 +11,7 @@ TypeParameterAccessors = "7e5a90cf-f82e-492e-a09b-e3e26432c138"
 
 [compat]
 Aqua = "0.8.9"
+FillArrays = "1.13"
 SafeTestsets = "0.1"
 Suppressor = "0.2"
 Test = "1.10"

--- a/test/extensions/test_fillarrays.jl
+++ b/test/extensions/test_fillarrays.jl
@@ -16,7 +16,8 @@ using FillArrays: Fill, Zeros, Ones
 
   @test @constinferred(set_type_parameters($Ta, eltype, $Float64)) ===
     Fill{Float64,ndims(a),typeof(axes(a))}
-  @test @constinferred(set_default_type_parameters($Ta)) === Fill{Float64,0,Tuple{}}
+  @test @constinferred(set_default_type_parameters($Ta)) ===
+    Fill{Float64,1,Tuple{Base.OneTo{Int}}}
 end
 
 @testset "Zeros" begin
@@ -30,7 +31,8 @@ end
 
   @test @constinferred(set_type_parameters($Ta, eltype, $Float64)) ===
     Zeros{Float64,ndims(a),typeof(axes(a))}
-  @test @constinferred(set_default_type_parameters($Ta)) === Zeros{Float64,0,Tuple{}}
+  @test @constinferred(set_default_type_parameters($Ta)) ===
+    Zeros{Float64,1,Tuple{Base.OneTo{Int}}}
 end
 
 @testset "Ones" begin
@@ -44,5 +46,6 @@ end
 
   @test @constinferred(set_type_parameters($Ta, eltype, $Float64)) ===
     Ones{Float64,ndims(a),typeof(axes(a))}
-  @test @constinferred(set_default_type_parameters($Ta)) === Ones{Float64,0,Tuple{}}
+  @test @constinferred(set_default_type_parameters($Ta)) ===
+    Ones{Float64,1,Tuple{Base.OneTo{Int}}}
 end

--- a/test/extensions/test_fillarrays.jl
+++ b/test/extensions/test_fillarrays.jl
@@ -1,0 +1,48 @@
+using Test: @testset
+using TestExtras: @constinferred
+
+using TypeParameterAccessors:
+  type_parameters, set_type_parameters, set_default_type_parameters
+using FillArrays: Fill, Zeros, Ones
+
+@testset "Fill" begin
+  a = Fill(1, 2, 2)
+  Ta = typeof(a)
+  tp = (eltype(a), ndims(a), typeof(axes(a)))
+  @test @constinferred(type_parameters($Ta)) === tp
+  @test @constinferred(type_parameters($a)) === tp
+  @test @constinferred(type_parameters($Ta, eltype)) === eltype(Ta)
+  @test @constinferred(type_parameters($Ta, ndims)) === ndims(Ta)
+
+  @test @constinferred(set_type_parameters($Ta, eltype, $Float64)) ===
+    Fill{Float64,ndims(a),typeof(axes(a))}
+  @test @constinferred(set_default_type_parameters($Ta)) === Fill{Float64,0,Tuple{}}
+end
+
+@testset "Zeros" begin
+  a = Zeros{Int}(2, 2)
+  Ta = typeof(a)
+  tp = (eltype(a), ndims(a), typeof(axes(a)))
+  @test @constinferred(type_parameters($Ta)) === tp
+  @test @constinferred(type_parameters($a)) === tp
+  @test @constinferred(type_parameters($Ta, eltype)) === eltype(Ta)
+  @test @constinferred(type_parameters($Ta, ndims)) === ndims(Ta)
+
+  @test @constinferred(set_type_parameters($Ta, eltype, $Float64)) ===
+    Zeros{Float64,ndims(a),typeof(axes(a))}
+  @test @constinferred(set_default_type_parameters($Ta)) === Zeros{Float64,0,Tuple{}}
+end
+
+@testset "Ones" begin
+  a = Ones{Int}(2, 2)
+  Ta = typeof(a)
+  tp = (eltype(a), ndims(a), typeof(axes(a)))
+  @test @constinferred(type_parameters($Ta)) === tp
+  @test @constinferred(type_parameters($a)) === tp
+  @test @constinferred(type_parameters($Ta, eltype)) === eltype(Ta)
+  @test @constinferred(type_parameters($Ta, ndims)) === ndims(Ta)
+
+  @test @constinferred(set_type_parameters($Ta, eltype, $Float64)) ===
+    Ones{Float64,ndims(a),typeof(axes(a))}
+  @test @constinferred(set_default_type_parameters($Ta)) === Ones{Float64,0,Tuple{}}
+end

--- a/test/extensions/test_stridedviews.jl
+++ b/test/extensions/test_stridedviews.jl
@@ -1,0 +1,21 @@
+using Test: @testset
+using TestExtras: @constinferred
+
+using TypeParameterAccessors: type_parameters, parenttype, set_type_parameters
+using StridedViews: StridedView
+
+@testset "StridedViews" begin
+  a = StridedView(zeros(Int, 2, 2))
+
+  Ta = typeof(a)
+  tp = (eltype(a), ndims(a), parenttype(a), typeof(a.op))
+  @test @constinferred(type_parameters($Ta)) === tp
+  @test @constinferred(type_parameters($a)) === tp
+  @test @constinferred(type_parameters($Ta, eltype)) === eltype(Ta)
+  @test @constinferred(type_parameters($Ta, ndims)) === ndims(Ta)
+  @test @constinferred(type_parameters($Ta, parenttype)) === parenttype(Ta)
+
+  @test @constinferred(
+    set_type_parameters($Ta, $((eltype, parenttype)), $((Float64, Matrix{Float64})))
+  ) === StridedView{Float64,2,Matrix{Float64},typeof(a.op)}
+end


### PR DESCRIPTION
This PR adds a package extension for defining some functions for FillArrays.
In particular, it is intended to resolve the type piracy [in UnallocatedArrays.jl](https://github.com/ITensor/UnallocatedArrays.jl/blob/7edaf5fbd7c86d0e832db0f076ddb5b629f6d1e3/src/abstractfill/abstractfill.jl#L19).

Simultaneously, I added some (minimal) tests for both package extensions.

One question I had is if we want to stick to the previous definition of UnallocatedArrays, defining methods in terms of `AbstractFill`. This removes some code repetition, and automatically defines some methods for UnallocatedArrays' types as well, but could possibly lead to wrong definitions in the future.
There already is precedence for taking the unsafe approach [for `AbstractArray` here](https://github.com/ITensor/TypeParameterAccessors.jl/blob/ebf7ea03338aad6c3a295537123e1f1bcddfc01b/src/base/abstractarray.jl#L78), but I have to admit that I feel very uncomfortable with defining things that return wrong results, rather than just throwing a `MethodError`, since that is typically quite easy to catch and fix. Here, I thus decided against that, but of course this can be changed if you prefer.

I changed the version to v0.2.1, since this should consist solely of additions and thus be non-breaking.