### PR TITLE
Determine `eltype` and `ndims` type parameter positions automatically

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,6 @@ authors = ["ITensor developers <support@itensor.org> and contributors"]
 version = "0.3.2"
 
 [deps]
-InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 SimpleTraits = "699a6c99-e7fa-54fc-8d76-47d257e15c1d"
 
@@ -30,7 +29,6 @@ TypeParameterAccessorsoneAPIExt = "oneAPI"
 AMDGPU = "0, 1"
 CUDA = "3, 4, 5"
 FillArrays = "1.13"
-InteractiveUtils = "1.10"
 JLArrays = "0.1, 0.2"
 LinearAlgebra = "1.10"
 Metal = "0, 1"

--- a/Project.toml
+++ b/Project.toml
@@ -1,9 +1,10 @@
 name = "TypeParameterAccessors"
 uuid = "7e5a90cf-f82e-492e-a09b-e3e26432c138"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
-version = "0.3.1"
+version = "0.3.2"
 
 [deps]
+InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 SimpleTraits = "699a6c99-e7fa-54fc-8d76-47d257e15c1d"
 
@@ -29,6 +30,7 @@ TypeParameterAccessorsoneAPIExt = "oneAPI"
 AMDGPU = "0, 1"
 CUDA = "3, 4, 5"
 FillArrays = "1.13"
+InteractiveUtils = "1.10"
 JLArrays = "0.1, 0.2"
 LinearAlgebra = "1.10"
 Metal = "0, 1"

--- a/src/base/abstractarray.jl
+++ b/src/base/abstractarray.jl
@@ -13,7 +13,7 @@ function position(type::Type{<:AbstractArray}, name)
   elseif base_type === type
     # Try to determine the position from the AbstractArray
     # supertype.
-    return position_from_supertype(type, AbstractArray, name)
+    return position_from_supertype(base_type, AbstractArray, name)
   end
   # See if there is a definition on the base type.
   return position(base_type, name)

--- a/src/base/abstractarray.jl
+++ b/src/base/abstractarray.jl
@@ -5,25 +5,6 @@ function set_type_parameters(type::Type, ::Self, param)
   return error("Can't set the parent type of an unwrapped array type.")
 end
 
-function position(type::Type{<:AbstractArray}, name)
-  base_type = unspecify_type_parameters(type)
-  if base_type === AbstractArray
-    # Use the AbstractArray position definitions.
-    return position(AbstractArray, name)
-  elseif base_type === type
-    # Try to determine the position from the AbstractArray
-    # supertype.
-    return position_from_supertype(base_type, AbstractArray, name)
-  end
-  # See if there is a definition on the base type.
-  return position(base_type, name)
-end
-
-# Fix ambiguity errors.
-position(::Type{<:AbstractArray}, pos::Int) = Position(pos)
-position(::Type{<:AbstractArray}, pos::Position) = pos
-position(::Type{<:AbstractArray}, ::Self) = Position(0)
-
 position(::Type{AbstractArray}, ::typeof(eltype)) = Position(1)
 position(::Type{AbstractArray}, ::typeof(ndims)) = Position(2)
 default_type_parameters(::Type{AbstractArray}) = (Float64, 1)

--- a/src/type_parameters.jl
+++ b/src/type_parameters.jl
@@ -27,30 +27,56 @@ function position end
 position(object, name) = position(typeof(object), name)
 position(::Type, pos::Int) = Position(pos)
 position(::Type, pos::Position) = pos
+
 function position(type::Type, name)
-  base_type = unspecify_type_parameters(type)
-  base_type === type && error("`position` not defined for $type and $name.")
-  return position(base_type, name)
+  type′ = unspecify_type_parameters(type)
+  if type === type′
+    # Fallback definition that determines the
+    # position automatically from the supertype of
+    # the type.
+    return position_from_supertype(type′, name)
+  end
+  return position(type′, name)
 end
 
-using InteractiveUtils: supertypes
+# Automatically determine the position of a type parameter of a type given
+# a supertype and the name of the parameter.
+function position_from_supertype(type::Type, name)
+  type′ = unspecify_type_parameters(type)
+  supertype_pos = position(supertype(type′), name)
+  return position_from_supertype_position(type′, supertype_pos)
+end
 
 # Automatically determine the position of a type parameter of a type given
-# a supertype and the position of the corresponding parameter in the supertype.
-@generated function position_from_supertype(
-  ::Type{T}, ::Type{ST}, pos::Position
-) where {T,ST}
-  supertype = supertypes(T)[findlast(t -> t <: ST, supertypes(T))]
-  params = Tuple(Base.unwrap_unionall(supertype).parameters)
-  param = params[Int(position(supertype, Int(pos)))]
-  if !(param isa TypeVar)
-    error("Position not found.")
-  end
-  new_pos = findfirst(p -> (p.name == param.name), get_type_parameters(T))
-  if isnothing(new_pos)
+# the supertype and the position of the corresponding parameter in the supertype.
+@generated function position_from_supertype_position(
+  ::Type{T}, supertype_pos::Position
+) where {T}
+  T′ = unspecify_type_parameters(T)
+  # The type parameters of the type as TypeVars.
+  # TODO: Ideally we would use `get_type_parameters`
+  # but that sometimes loses TypeVar names:
+  # https://github.com/ITensor/TypeParameterAccessors.jl/issues/30
+  type_params = Base.unwrap_unionall(T′).parameters
+  # The type parameters of the immediate supertype as TypeVars.
+  # This has TypeVars with names that correspond to the names of
+  # the TypeVars of the type parameters of `T`, for example:
+  # ```julia
+  # julia> struct MyArray{B,A} <: AbstractArray{A,B} end
+  #
+  # julia> Base.unwrap_unionall(MyArray).parameters
+  # svec(B, A)
+  #
+  # julia> Base.unwrap_unionall(supertype(MyArray)).parameters
+  # svec(A, B)
+  # ```
+  supertype_params = Base.unwrap_unionall(supertype(T)).parameters
+  supertype_param = supertype_params[Int(supertype_pos)]
+  pos = findfirst(param -> (param.name == supertype_param.name), type_params)
+  if isnothing(pos)
     return error("Position not found.")
   end
-  return :(@inline; $(Position(new_pos)))
+  return :(@inline; $(Position(pos)))
 end
 
 # Automatically determine the position of a type parameter of a type given

--- a/test/test_basics.jl
+++ b/test/test_basics.jl
@@ -87,13 +87,26 @@ end
 @testset "Automatic fallback for position" begin
   struct MyArray{B,A} <: AbstractArray{A,B} end
   @test @constinferred(TypeParameterAccessors.position(MyArray, eltype)) == Position(2)
+  @test @constinferred(TypeParameterAccessors.position(MyArray{3,Float32}, eltype)) ==
+    Position(2)
   @test @constinferred(TypeParameterAccessors.position(MyArray, ndims)) == Position(1)
+  @test @constinferred(TypeParameterAccessors.position(MyArray{3,Float32}, ndims)) ==
+    Position(1)
 
   struct MyVector{X,Y,A<:Real} <: AbstractArray{A,1} end
   @test @constinferred(TypeParameterAccessors.position(MyVector, eltype)) == Position(3)
+  @test @constinferred(
+    TypeParameterAccessors.position(MyVector{Int,(1, 2),Float32}, eltype)
+  ) == Position(3)
   @test_throws ErrorException TypeParameterAccessors.position(MyVector, ndims)
+  @test_throws ErrorException TypeParameterAccessors.position(
+    MyVector{Int,(1, 2),Float32}, ndims
+  )
 
   struct MyBoolArray{X,Y,Z,B} <: AbstractArray{Bool,B} end
   @test_throws ErrorException TypeParameterAccessors.position(MyBoolArray, eltype)
+  @test_throws ErrorException TypeParameterAccessors.position(MyBoolArray{1,2,3,4}, eltype)
   @test @constinferred(TypeParameterAccessors.position(MyBoolArray, ndims)) == Position(4)
+  @test @constinferred(TypeParameterAccessors.position(MyBoolArray{1,2,3,4}, ndims)) ==
+    Position(4)
 end


### PR DESCRIPTION
This brings back the functionality removed in https://github.com/ITensor/TypeParameterAccessors.jl/pull/26 but with a more robust strategy.

This uses the fact that when an AbstractArray subtype with unconventional type parameter positions for `eltype` and `ndims` is defined, the information of where those type parameters are defined can be determined by matching the names of the TypeVars of the type parameters to the same name in the AbstractArray type output by `InteractiveUtils.supertypes`, for example:
```julia
julia> struct MyBoolArray{X,Y,Z,B} <: AbstractArray{Bool,B} end

julia> supertypes(MyBoolArray)
(MyBoolArray, AbstractArray{Bool}, Any)

julia> Base.unwrap_unionall(supertypes(MyBoolArray)[1]).parameters
svec(X, Y, Z, B)

julia> Base.unwrap_unionall(supertypes(MyBoolArray)[2]).parameters
svec(Bool, B)
```
So you can see that we can determine that the 4th parameter of `MyBoolArray` must be the `ndims` type parameter, since it has a name `B` matching the `ndims` parameter of its AbstractArray supertype.

In principle this can work with non-AbstractArray types (using the internal function `TypeParameterAccessors.position_from_supertype`) but for now that is opt-in and an internal feature.