### PR TITLE
Define `similartype` for `BitArray`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TypeParameterAccessors"
 uuid = "7e5a90cf-f82e-492e-a09b-e3e26432c138"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
-version = "0.3.3"
+version = "0.3.4"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TypeParameterAccessors"
 uuid = "7e5a90cf-f82e-492e-a09b-e3e26432c138"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
-version = "0.3.2"
+version = "0.3.3"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/base/similartype.jl
+++ b/src/base/similartype.jl
@@ -28,6 +28,13 @@ end
   return set_eltype(arraytype, eltype)
 end
 
+function similartype(arraytype::Type{<:BitArray}, elt::Type)
+  if is_parameter_specified(arraytype, ndims)
+    return Array{elt,ndims(arraytype)}
+  end
+  return Array{elt}
+end
+
 @traitfn function similartype(
   arraytype::Type{ArrayT}, dims::Tuple
 ) where {ArrayT; !IsWrappedArray{ArrayT}}

--- a/test/test_similartype.jl
+++ b/test/test_similartype.jl
@@ -1,5 +1,6 @@
-using Test: @test, @test_broken, @testset
 using LinearAlgebra: Adjoint, Diagonal
+using Test: @test, @test_broken, @testset
+using TestExtras: @constinferred
 using TypeParameterAccessors: NDims, similartype
 
 @testset "TypeParameterAccessors similartype" begin
@@ -10,10 +11,14 @@ using TypeParameterAccessors: NDims, similartype
   @test similartype(Array, NDims(2)) == Matrix
   @test similartype(Array, Float64, (2, 2)) == Matrix{Float64}
   @test similartype(Array, Float64, NDims(2)) == Matrix{Float64}
+
+  # Adjoint
   @test similartype(Adjoint{Float32,Matrix{Float32}}, Float64, (2, 2, 2)) ==
     Array{Float64,3}
   @test similartype(Adjoint{Float32,Matrix{Float32}}, Float64, NDims(3)) == Array{Float64,3}
   @test similartype(Adjoint{Float32,Matrix{Float32}}, Float64) == Matrix{Float64}
+
+  # Diagonal
   @test similartype(Diagonal{Float32,Vector{Float32}}) == Matrix{Float32}
   @test similartype(Diagonal{Float32,Vector{Float32}}, Float64) == Matrix{Float64}
   @test similartype(Diagonal{Float32,Vector{Float32}}, (2, 2, 2)) == Array{Float32,3}
@@ -22,4 +27,12 @@ using TypeParameterAccessors: NDims, similartype
     Array{Float64,3}
   @test similartype(Diagonal{Float32,Vector{Float32}}, Float64, NDims(3)) ==
     Array{Float64,3}
+
+  # BitArray
+  @test @constinferred(similartype(BitArray, Float32)) == Array{Float32}
+  @test @constinferred(similartype(BitVector, Float32)) == Vector{Float32}
+  @test @constinferred(similartype(BitArray, Float32, (2, 2, 2))) == Array{Float32,3}
+  @test @constinferred(similartype(BitVector, Float32, (2, 2, 2))) == Array{Float32,3}
+  @test @constinferred(similartype(BitArray, Float32, NDims(3))) == Array{Float32,3}
+  @test @constinferred(similartype(BitVector, Float32, NDims(3))) == Array{Float32,3}
 end

--- a/test/test_similartype.jl
+++ b/test/test_similartype.jl
@@ -29,6 +29,12 @@ using TypeParameterAccessors: NDims, similartype
     Array{Float64,3}
 
   # BitArray
+  @test @constinferred(similartype(BitArray)) == BitArray
+  @test @constinferred(similartype(BitVector)) == BitVector
+  @test @constinferred(similartype(BitArray, (2, 2, 2))) == BitArray{3}
+  @test @constinferred(similartype(BitVector, (2, 2, 2))) == BitArray{3}
+  @test @constinferred(similartype(BitArray, NDims(3))) == BitArray{3}
+  @test @constinferred(similartype(BitVector, NDims(3))) == BitArray{3}
   @test @constinferred(similartype(BitArray, Float32)) == Array{Float32}
   @test @constinferred(similartype(BitVector, Float32)) == Vector{Float32}
   @test @constinferred(similartype(BitArray, Float32, (2, 2, 2))) == Array{Float32,3}


### PR DESCRIPTION
This defines `similartype` for `BitArray` such that it converts to `Array` when a new element type is specified:
```julia
julia> similartype(BitVector, Float32)
Vector{Float32} (alias for Array{Float32, 1})

julia> similar(trues(4), Float32)
4-element Vector{Float32}:
 3.0f-45
 0.0
 4.0f-45
 0.0

julia> similartype(BitVector, Float32, (2, 2, 2))
Array{Float32, 3}

julia> similar(trues(4), Float32, (2, 2, 2))
2×2×2 Array{Float32, 3}:
[:, :, 1] =
 1.71959f36  2.36936f-38
 1.0f-45     7.19f-43

[:, :, 2] =
 2.0313f-24  9.68599f-24
 1.0f-45     1.0f-45
```
while it stays a `BitArray` if the element type isn't specified:
```julia
julia> similartype(BitVector)
BitVector (alias for BitArray{1})

julia> similar(trues(4))
4-element BitVector:
 0
 0
 0
 0

julia> similartype(BitVector, (2, 2))
BitMatrix (alias for BitArray{2})

julia> similar(trues(4), (2, 2))
2×2 BitMatrix:
 0  0
 0  0
```