### PR TITLE
Define `complextype`, `realtype`, `imagtype`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TypeParameterAccessors"
 uuid = "7e5a90cf-f82e-492e-a09b-e3e26432c138"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
-version = "0.4.0"
+version = "0.4.1"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/TypeParameterAccessors.jl
+++ b/src/TypeParameterAccessors.jl
@@ -18,6 +18,7 @@ include("type_parameters.jl")
 include("ndims.jl")
 include("base/abstractarray.jl")
 include("base/similartype.jl")
+include("base/complextype.jl")
 include("base/linearalgebra.jl")
 
 end

--- a/src/base/complextype.jl
+++ b/src/base/complextype.jl
@@ -1,0 +1,22 @@
+for f in [:complex, :real]
+  ftype = Symbol(f, :type)
+  @eval begin
+    $ftype(a::AbstractArray) = $ftype(typeof(a))
+    function $ftype(A::Type{<:AbstractArray})
+      return Base.promote_op($f, A)
+    end
+    $ftype(x::Number) = $f(typeof(x))
+    $ftype(::Type{T}) where {T<:Number} = $f(T)
+    $ftype(::Type{<:Type{T}}) where {T<:Number} = $f(T)
+  end
+end
+
+imagtype(a::AbstractArray) = imagtype(typeof(a))
+function imagtype(A::Type{<:AbstractArray})
+  return Base.promote_op(imag, A)
+end
+imagtype(x::Number) = imagtype(typeof(x))
+# This works around the fact that `imag(::Type{<:Number})`
+# isn't defined in `Base`.
+imagtype(::Type{T}) where {T<:Number} = Base.promote_op(imag, T)
+imagtype(::Type{<:Type{T}}) where {T<:Number} = imagtype(T)

--- a/test/test_basics.jl
+++ b/test/test_basics.jl
@@ -4,6 +4,9 @@ using TestExtras: @constinferred
 using TypeParameterAccessors:
   TypeParameterAccessors,
   Position,
+  complextype,
+  imagtype,
+  realtype,
   set_type_parameters,
   specify_type_parameters,
   type_parameters,
@@ -109,4 +112,30 @@ end
   @test @constinferred(TypeParameterAccessors.position(MyBoolArray, ndims)) == Position(4)
   @test @constinferred(TypeParameterAccessors.position(MyBoolArray{1,2,3,4}, ndims)) ==
     Position(4)
+end
+
+@testset "complextype, realtype, imagtype" begin
+  @test complextype(Float32(1.2)) === ComplexF32
+  @test complextype(Float32(1.2) + Float32(2.3) * im) === ComplexF32
+  @test complextype(Float32) === ComplexF32
+  @test complextype(ComplexF32) === ComplexF32
+  @test complextype(Type{Float32}) === ComplexF32
+  @test complextype(Type{ComplexF32}) === ComplexF32
+  @test complextype(randn(Float32, 2, 2)) === Matrix{ComplexF32}
+  @test complextype(randn(ComplexF32, 2, 2)) === Matrix{ComplexF32}
+  @test complextype(Matrix{Float32}) === Matrix{ComplexF32}
+  @test complextype(Matrix{ComplexF32}) === Matrix{ComplexF32}
+
+  for f in (realtype, imagtype)
+    @test @constinferred(f(Float32(1.2))) === Float32
+    @test @constinferred(f(Float32(1.2) + Float32(2.3) * im)) === Float32
+    @test @constinferred(f(Float32)) === Float32
+    @test @constinferred(f(ComplexF32)) === Float32
+    @test @constinferred(f(Type{Float32})) === Float32
+    @test @constinferred(f(Type{ComplexF32})) === Float32
+    @test @constinferred(f(randn(Float32, 2, 2))) === Matrix{Float32}
+    @test @constinferred(f(randn(ComplexF32, 2, 2))) === Matrix{Float32}
+    @test @constinferred(f(Matrix{Float32})) === Matrix{Float32}
+    @test @constinferred(f(Matrix{ComplexF32})) === Matrix{Float32}
+  end
 end


### PR DESCRIPTION
Define type space versions of `Base.complex`, `Base.real`, `Base.imagtype`, analogous to #51 which defines `similartype` as a type space version of `Base.similar`.

The motivation for this is making block sparse matrix SVD more generic, specifically this helps generalize these lines: https://github.com/ITensor/BlockSparseArrays.jl/blob/f9b971b7aafb2cdaf828160863da87676ba07f0f/src/factorizations/svd.jl#L27-L30 where we construct the block type of the matrix of singular values. (This is one approach to that, another approach would be to infer the block types of U, S, and V by calling `Base.promote_op(svd_compact, blocktype(A))`, I'll play around with both approaches but even if this PR isn't used for that particular case I think it is still useful.)