### PR TITLE
UnWrap_Array

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TypeParameterAccessors"
 uuid = "7e5a90cf-f82e-492e-a09b-e3e26432c138"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
-version = "0.4.2"
+version = "0.4.3"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/base/abstractarray.jl
+++ b/src/base/abstractarray.jl
@@ -46,6 +46,12 @@ is_wrapped_array(arraytype::Type{<:AbstractArray}) = (parenttype(arraytype) ≠ 
 
 using SimpleTraits: Not, @traitfn
 
+function unwrap_array(a::AbstractArray)
+  p = parent(a)
+  p ≡ a && return a
+  return unwrap_array(p)
+end
+
 @traitfn function unwrap_array_type(
   arraytype::Type{ArrayType}
 ) where {ArrayType;IsWrappedArray{ArrayType}}

--- a/test/test_wrappers.jl
+++ b/test/test_wrappers.jl
@@ -114,7 +114,7 @@ using TypeParameterAccessors:
     @test @inferred(parenttype(wrapped_array)) <:
       Base.ReshapedArray{Float64,1,Transpose{Float64,Matrix{Float64}}}
     @test @inferred(unwrap_array_type(array)) == Matrix{Float64}
-    @test unwrap_array(unwrap_array(unwrap_array(wrapped_array))) == array
+    @test unwrap_array(wrapped_array) == array
   end
 
   @testset "StridedView" begin

--- a/test/test_wrappers.jl
+++ b/test/test_wrappers.jl
@@ -20,6 +20,7 @@ using TypeParameterAccessors:
   set_ndims,
   set_parenttype,
   unspecify_type_parameters,
+  unwrap_array,
   unwrap_array_type
 
 @testset "TypeParameterAccessors wrapper types" begin
@@ -82,6 +83,7 @@ using TypeParameterAccessors:
         @test @inferred set_eltype(wrapped_array, Float32) isa
           wrapper{Float32,Matrix{Float32}}
       end
+      @test unwrap_array(wrapped_array) == array
     end
   end
 
@@ -100,6 +102,8 @@ using TypeParameterAccessors:
       @test @inferred(set_eltype(wrapped_array, Float32)) isa
         Diagonal{Float32,Vector{Float32}}
     end
+    #Diagonal is not a wrapper?
+    @test unwrap_array(wrapped_array) != array
   end
 
   @testset "LinearAlgebra nested wrappers" begin
@@ -110,15 +114,18 @@ using TypeParameterAccessors:
     @test @inferred(parenttype(wrapped_array)) <:
       Base.ReshapedArray{Float64,1,Transpose{Float64,Matrix{Float64}}}
     @test @inferred(unwrap_array_type(array)) == Matrix{Float64}
+    @test unwrap_array(unwrap_array(unwrap_array(wrapped_array))) == array
   end
 
   @testset "StridedView" begin
     array = randn(2, 2)
-    wrapped_array = StridedView(randn(2, 2))
+    wrapped_array = StridedView(array)
     wrapped_array_type = typeof(wrapped_array)
     @test @inferred(is_wrapped_array(wrapped_array)) == true
     unwrapped_type = VERSION ≥ v"1.11-" ? Memory{Float64} : Vector{Float64}
     @test @inferred(parenttype(wrapped_array)) === unwrapped_type
     @test @inferred(unwrap_array_type(wrapped_array_type)) === unwrapped_type
+    #StridedView is not a wrapper?
+    @test unwrap_array(wrapped_array) != array
   end
 end


### PR DESCRIPTION
This `PR` adds the `unwrap_array` function to perform a recursive unwrapping on a wrapped array. 

Tests are included.

@mtfishman `StridedView(array)` and `Diagonal(array)` appear to not act as wrappers from these tests? Or at least it doesn't appear to work when I try to unwrap them