### PR TITLE
CompatHelper: bump compat for CUDA in [weakdeps] to 6, (keep existing compat)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "TypeParameterAccessors"
 uuid = "7e5a90cf-f82e-492e-a09b-e3e26432c138"
-version = "0.4.21"
+version = "0.4.22"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
 
 [workspace]
@@ -30,7 +30,7 @@ TypeParameterAccessorsoneAPIExt = "oneAPI"
 
 [compat]
 AMDGPU = "0, 1, 2"
-CUDA = "3, 4, 5"
+CUDA = "3, 4, 5, 6"
 FillArrays = "1.13"
 JLArrays = "0.1, 0.2, 0.3"
 LinearAlgebra = "1.10"


### PR DESCRIPTION
This pull request changes the compat entry for the `CUDA` package from `3, 4, 5` to `3, 4, 5, 6`.
This keeps the compat entries for earlier versions.



Note: I have not tested your package with this new compat entry.
It is your responsibility to make sure that your package tests pass before you merge this pull request.