### PR TITLE
CompatHelper: bump compat for StridedViews in [weakdeps] to 0.5, (keep existing compat)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "TypeParameterAccessors"
 uuid = "7e5a90cf-f82e-492e-a09b-e3e26432c138"
-version = "0.4.21"
+version = "0.4.22"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
 
 [workspace]
@@ -36,6 +36,6 @@ JLArrays = "0.1, 0.2, 0.3"
 LinearAlgebra = "1.10"
 Metal = "0, 1"
 SimpleTraits = "0.9.4"
-StridedViews = "0.3.2, 0.4"
+StridedViews = "0.3.2, 0.4, 0.5"
 julia = "1.10"
 oneAPI = "0, 1, 2"


### PR DESCRIPTION
This pull request changes the compat entry for the `StridedViews` package from `0.3.2, 0.4` to `0.3.2, 0.4, 0.5`.
This keeps the compat entries for earlier versions.



Note: I have not tested your package with this new compat entry.
It is your responsibility to make sure that your package tests pass before you merge this pull request.