### PR TITLE
Fix UndefVarError on CUDA.jl v6.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "TypeParameterAccessors"
 uuid = "7e5a90cf-f82e-492e-a09b-e3e26432c138"
-version = "0.4.22"
+version = "0.4.23"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
 
 [workspace]

--- a/ext/TypeParameterAccessorsCUDAExt.jl
+++ b/ext/TypeParameterAccessorsCUDAExt.jl
@@ -3,10 +3,17 @@ module TypeParameterAccessorsCUDAExt
 using CUDA: CUDA, CuArray
 using TypeParameterAccessors: TypeParameterAccessors, Position
 
+# CUDA.jl v6.0 moved `default_memory` from `CUDA` to `CUDA.CUDACore`.
+const default_memory = if isdefined(CUDA, :default_memory)
+    CUDA.default_memory
+else
+    CUDA.CUDACore.default_memory
+end
+
 TypeParameterAccessors.position(::Type{<:CuArray}, ::typeof(eltype)) = Position(1)
 TypeParameterAccessors.position(::Type{<:CuArray}, ::typeof(ndims)) = Position(2)
 function TypeParameterAccessors.default_type_parameters(::Type{<:CuArray})
-    return (Float64, 1, CUDA.default_memory)
+    return (Float64, 1, default_memory)
 end
 
 end


### PR DESCRIPTION
Closes #124.

CUDA.jl v6.0 refactored its module structure: `default_memory` moved from `CUDA` to `CUDA.CUDACore`. The extension's reference to `CUDA.default_memory` therefore raises `UndefVarError` on every downstream that pairs this package with CUDA v6.0.

Resolve `default_memory` once at extension load via `isdefined(CUDA, :default_memory)`, falling back to `CUDA.CUDACore.default_memory` on CUDA.jl v6+.

Tested by the original reporter against CUDA.jl v5.11.1 and v6.0.0.